### PR TITLE
Update Go to 1.8.1 and musl to 1.1.16 versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,20 @@
-FROM golang:1.5.1-alpine
+FROM golang:1.8.1-alpine
 
+ENV MUSL_VERSION=1.1.16
 
 # https://pkgs.alpinelinux.org/package/main/x86/build-base
-RUN apk add --update-cache build-base musl-dev musl-utils tar sudo
+RUN apk add --update-cache build-base tar && \
+    rm -rf /var/cache/apk/*
 
-RUN wget http://www.musl-libc.org/releases/musl-1.1.10.tar.gz && tar -xvf musl-1.1.10.tar.gz && cd musl-1.1.10 && ./configure && make && sudo make install && cd .. && rm musl-1.1.10.tar.gz && rm -Rf musl-1.1.10 && rm -Rf musl.1.1.10 && rm -Rf musl.1.1.10
+RUN wget http://www.musl-libc.org/releases/musl-${MUSL_VERSION}.tar.gz && \
+    tar -xvf musl-${MUSL_VERSION}.tar.gz && \
+    cd musl-${MUSL_VERSION} && \
+    ./configure && \
+    make && \
+    make install && \
+    cd .. && \
+    rm musl-${MUSL_VERSION}.tar.gz && \
+    rm -Rf musl-${MUSL_VERSION}
 
-RUN rm -rf /var/cache/apk/*
-
-ENV GO15VENDOREXPERIMENT=1
 
 CMD go build --ldflags '-linkmode external -extldflags "-static"'


### PR DESCRIPTION
This change does 3 things:

1. Updates go to 1.8.1
2. Updates musl to 1.1.16
3. Minor cleanup in the Dockerfile to simplify